### PR TITLE
Cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ dkms.conf
 
 .vscode
 game
-/build/
+/build*/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dkms.conf
 
 .vscode
 game
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ dkms.conf
 
 .vscode
 game
-/build*/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(game)
+
+find_package(raylib REQUIRED)
+
+set(SOURCE_PREFIX ${CMAKE_CURRENT_LIST_DIR})
+set(GAME_SOURCES 
+    ${SOURCE_PREFIX}/main.c
+)
+
+add_executable(${PROJECT_NAME} "")
+target_sources(${PROJECT_NAME} PUBLIC ${GAME_SOURCES})
+target_link_libraries(${PROJECT_NAME} PRIVATE raylib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,15 @@ cmake_minimum_required(VERSION 3.10)
 
 project(game)
 
-find_package(raylib REQUIRED)
-
-set(SOURCE_PREFIX ${CMAKE_CURRENT_LIST_DIR})
-set(GAME_SOURCES 
-    ${SOURCE_PREFIX}/main.c
+# Add you sources to this variable definition
+set(GAME_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/main.c
 )
 
 add_executable(${PROJECT_NAME} "")
+
+find_package(raylib CONFIG REQUIRED)
+
 target_sources(${PROJECT_NAME} PUBLIC ${GAME_SOURCES})
-target_link_libraries(${PROJECT_NAME} PRIVATE raylib)
+target_include_directories(${PROJECT_NAME} PRIVATE ${raylib_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${raylib_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -9,3 +9,24 @@
 - Quit pressing the "Escape" key!
 - Experience dynamic allocation of new wrappers when placing too many houses!
 - Experience some of the houses not being correctly rendered if you move too far away from your starting point!
+
+### Building with cmake
+
+This project has an CMakeLists.txt setup for generating a plethora of build scripts for build systems
+such as GNU Makefile, Ninja, and NMake (Visual Studio).
+
+Generating the build script with cmake can be done in various ways, but doing the following will
+generate an build script with the default build systems of your platform:
+```
+## Assuming you are in project root
+$ cmake -S . -B build
+```
+This will create an directory `build` with the build scripts. You can start the build process with
+cmake:
+```
+$ cmake --build ./build/
+```
+This will run the relevant build script in `build`.
+
+The current `CMakeLists.txt` file is tested on both Windows (with the `VCPKG 2020.11` package manager
+to find the raylib dependency) and Debian.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 
 ### Building with cmake
 
-This project has an CMakeLists.txt setup for generating a plethora of build scripts for build systems
+This project has a CMakeLists.txt setup for generating a plethora of build scripts for build systems
 such as GNU Makefile, Ninja, and NMake (Visual Studio).
 
-Generating the build script with cmake can be done in various ways, but doing the following will
-generate an build script with the default build systems of your platform:
+Generating the build script with CMake can be done in various ways, but doing the following will
+generate a build script with the default build systems of your platform:
 ```
 ## Assuming you are in project root
 $ cmake -S . -B build
 ```
-This will create an directory `build` with the build scripts. You can start the build process with
-cmake:
+This will create a directory `build` with the build scripts. You can start the build process with
+CMake:
 ```
 $ cmake --build ./build/
 ```


### PR DESCRIPTION
Instead having an specific Linux Makefile, this CMakeLists.txt can generate both Visual Studio build scripts and an Makefile for Linux.
Some documentation is put in the README file. 