### PR TITLE
Cmake compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(${PROJECT_NAME} "")
 
 find_package(raylib CONFIG REQUIRED)
 
-target_sources(${PROJECT_NAME} PUBLIC ${GAME_SOURCES})
+target_sources(${PROJECT_NAME} PRIVATE ${GAME_SOURCES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${raylib_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${raylib_LIBRARIES})
 target_compile_options(${PROJECT_NAME} PRIVATE ${COMPILER_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,15 @@ set(GAME_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/main.c
 )
 
+# Compiler flags per compiler, first is clang and gcc, next is MS VC
+set(COMPILER_FLAGS
+   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+      -Wall -Wextra -O2
+   >
+   $<$<CXX_COMPILER_ID:MSVC>:
+      /W4 /Ot
+   >)
+
 add_executable(${PROJECT_NAME} "")
 
 find_package(raylib CONFIG REQUIRED)
@@ -14,3 +23,4 @@ find_package(raylib CONFIG REQUIRED)
 target_sources(${PROJECT_NAME} PUBLIC ${GAME_SOURCES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${raylib_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${raylib_LIBRARIES})
+target_compile_options(${PROJECT_NAME} PRIVATE ${COMPILER_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(game)
+project(game C)
 
 # Add you sources to this variable definition
 set(GAME_SOURCES
@@ -9,10 +9,10 @@ set(GAME_SOURCES
 
 # Compiler flags per compiler, first is clang and gcc, next is MS VC
 set(COMPILER_FLAGS
-   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+   $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:TinyCC>>:
       -Wall -Wextra -O2
    >
-   $<$<CXX_COMPILER_ID:MSVC>:
+   $<$<C_COMPILER_ID:MSVC>:
       /W4 /Ot
    >)
 


### PR DESCRIPTION
Adding compiler flags for clang, clang (Mac), gcc and MSVC (Windows). 

Clang and gcc share compiler flags, and MSVC has its own.

The Compiler flags are implemented using generating expressions which are expresses that are generated given some condition (here the current compiler id). This can also be expanded to cover debug vs release flags f.x.